### PR TITLE
adding new token confirmation page

### DIFF
--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -8,6 +8,7 @@ import {Route, Switch} from "react-router-dom";
 import Sell from "./components/pages/Sell/Sell";
 import Menu from "./components/ui/menu/Menu";
 import Home from "./components/pages/Home/Home";
+import Onboard from "./components/pages/Onboard/Onboard";
 import CreateWorkItem from "./components/pages/CreateWorkItem/CreateWorkItem";
 import IpfsService from "./components/service/IpfsService";
 
@@ -45,6 +46,12 @@ function AppContainer() {
                 </Route>
                 <Route path="/work/create">
                     <CreateWorkItem saveWorkItem={saveToIpfs}/>
+                </Route>
+                {/* <Route path="/admin">
+                    <Admin/>
+                </Route> */}
+                <Route path="/onboard">
+                    <Onboard onboardItems={saveToIpfs}/>
                 </Route>
             </Switch>
         </div>
@@ -126,6 +133,15 @@ const sellItems = [
         name: 'Beverage',
         price: '1'
     }
+];
+
+const onboardItems = [
+    {
+        address: '',
+        balance: 'Lunch Meal',
+        username: '5',
+        password: '123'
+    },
 ];
 
 

--- a/src/components/pages/Onboard/Onboard.js
+++ b/src/components/pages/Onboard/Onboard.js
@@ -1,0 +1,109 @@
+import React, {useState} from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
+import './Onboard.scss';
+import Image from '../../static/images/Wolf-Pack-Logo-Dark-01.png';
+import OnboardForm from './OnboardForm'
+
+function OnboardItem(props) {
+
+    const [newToken] = useState({
+        pup: '0x02345230487203982039847502938745589',
+        balance: '5.00',
+    });
+
+
+    const useStyles = makeStyles(theme => ({
+        root: {
+          flexGrow: 1,
+          padding: "1.2em 24px",
+          color: theme.palette.text.secondary,
+          backgroundColor: "#6CC9CD",
+        },
+        card: {
+            backgroundColor: '#FAFAFA',
+            padding: '.4em',
+        },
+        pageHeading: {
+          fontSize: '32px',
+          marginTop: '.6em',
+          paddingTop: '.6em',
+          marginBottom: '.6em',
+          paddingBottom: '.6em',
+          [theme.breakpoints.down('xs')]: {
+            fontSize: '1.6rem',
+          },
+        },
+        paper: {
+          padding: theme.spacing(2),
+          textAlign: 'center',
+          color: theme.palette.text.secondary,
+        },
+        tokenContainer: {
+            marginTop: '2em',
+            background: 'url({Image}) 50% 50% no-repeat',
+        },
+        ethAddress: {
+            width: '100%',
+            padding: '.6em',
+            backgroundColor: 'white',
+            color: '#9B9B9B',
+
+        }
+    }));
+    const classes = useStyles(); 
+
+    return (
+    <div className="container">
+        <Typography variant="h3" className={classes.pageHeading}>
+            New Token Confirmation
+        </Typography>
+        <Typography variant="body1" >
+            Found! This token is ready for use with a $5.00 balance.
+        </Typography>
+
+        <div className={classes.tokenContainer}>
+            <Typography variant="body2" >
+                Token
+            </Typography>
+
+            <Card className={classes.card}>
+                <CardContent>
+                    <Typography className={classes.title} color="textSecondary" gutterBottom>
+                    Token Type
+                    </Typography>
+                    <Typography variant="h5" component="h2">
+                    Pup
+                    </Typography>
+                    <Typography variant="caption" className={classes.ethAddress} >
+                        {newToken.pup}
+                    </Typography>
+                    
+                </CardContent>
+                <CardActions>
+                    $ <Button size="small">{newToken.balance}</Button>
+                </CardActions>
+            </Card>
+
+
+            {/* Form */}
+            <OnboardForm/>
+
+        </div>
+        
+    </div>
+    )
+}
+
+OnboardItem.propTypes = {
+    OnboardItem: PropTypes.func.isRequired
+};
+
+OnboardItem.defaultProps = {};
+
+export default OnboardItem;

--- a/src/components/pages/Onboard/Onboard.scss
+++ b/src/components/pages/Onboard/Onboard.scss
@@ -1,0 +1,19 @@
+.onboard {
+    margin: 10px;
+    border: solid #ccc 2px;
+    box-shadow: 0 1px #ccc;
+    border-radius: 10px;
+    padding: 10px;
+  }
+  
+  .onboard-input{
+    display: flex;
+    justify-content: center;
+  }
+  
+  .inputs-flex{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  

--- a/src/components/pages/Onboard/OnboardForm.js
+++ b/src/components/pages/Onboard/OnboardForm.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    '& > *': {
+      width: '100%',
+    },
+  },
+  simpleFieldWrapper: {
+      margin: '.6em 0',
+
+  }
+}));
+
+export default function BasicTextFields() {
+  const classes = useStyles();
+
+  return (
+    <form className={classes.root} noValidate autoComplete="off">
+      <TextField id="user-email" label="email" type="email" className={classes.simpleFieldWrapper} />
+      <TextField id="user-pin" label="pin" type="password" className={classes.simpleFieldWrapper} />
+      <Button variant="contained" color="primary">
+        Initialize Token
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
Using material-ui for components, this builds out the token-found page (after scanning a coin). No logic applied, just placeholders for now.

